### PR TITLE
WIP: Add CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Traiv
+.push-token*
 # ---> TeX
 ## Core latex/pdflatex auxiliary files:
 *.aux

--- a/.push-token.enc
+++ b/.push-token.enc
@@ -1,0 +1,1 @@
+`Ðd2¦T%Ê^ç?¹ìÖ"d°úÐNk;×eõ5©c4³¡ðü&jdâ‚ÃØ6Þb’ÇÛE——öÅsümv:ø#¼TØ	ØhUÆU¶¶áÕ”bâôÎ&žÂ?Åi Ã¬:´PŠÎxùÉm‡±âÓ·Ë_rìQâèKìµSàA O’y ³µ1 —Ïc¸Åäì*)ê\œh$-Õ´ªœ«)à(™’Jáø¢°§ù»|:Âþkƒ“·Ó~Øc^!†;‹ßÄg“ðÙÌH<x#EÃÔ2†d:C6›è4LÅ3“zgDª‰9Ÿ™XÃnQ‰¥5‹C‡1(7Âé¾ÝŒ•þs¾·±¤F¶=<í¹¾ìHp–J½ësF#êaCAÎ¢ž@Á™ð2’åyÈ)o™¬DëðcÉÓ"]¤nÛŸ%üT.œz4Ž;èC1ùR€±óŠÊ#Ô“t•tV8‹4™w)›š³”‡ÔÚØ€énd‹áé¬†rW‰eOEßLCl0ç^ºwKF_“­&0"ÂÖƒ

--- a/.push.sh
+++ b/.push.sh
@@ -9,7 +9,7 @@ fi
 convert -density 600 test.pdf -quality 90 test.png
 
 # TODO: change env variabels encrypted_*
-openssl aes-256-cbc -K $encrypted_e6cc0fb2b8da_key -iv $encrypted_e6cc0fb2b8da_iv -in .push-token.enc -out push-token -d
+openssl aes-256-cbc -K $encrypted_da622da7f4d3_key -iv $encrypted_da622da7f4d3_iv -in .push-token.enc -out .push-token -d
 chmod 600 push-token
 eval $(ssh-agent -s)
 ssh-add push-token

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+# based on: https://github.com/PHPirates/travis-ci-latex-pdf
+language: generic
+before_install:
+- sudo apt-get install -y imagemagick ghostscript
+# converting PDFs is disabled by default (for security)
+- sudo sed -i '/PDF/s/none/write|read/g' /etc/ImageMagick-6/policy.xml
+install:
+- export PATH="$HOME/miniconda/bin:$PATH"
+- if ! command -v conda > /dev/null; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  -O miniconda.sh; bash miniconda.sh -b -p $HOME/miniconda -u; conda config --add
+  channels conda-forge; conda config --set always_yes yes; conda install tectonic==0.1.11;
+  fi
+cache:
+  directories:
+  - "$HOME/miniconda"
+  - "$HOME/.cache/Tectonic"
+script:
+- tectonic ./cv.tex --print
+- tectonic ./cover.tex --print
+before_deploy:
+- convert -density 600 cv.pdf -quality 90 cv.png
+- convert -density 600 cover.pdf -quality 90 cover.png
+deploy:
+  provider: releases
+  api_key:
+    secure: # TODO add key
+  file:
+  - cv.pdf
+  - cover.pdf
+  skip_cleanup: true
+  on:
+    tags: true
+after_deploy:
+- git remote add origin-token https://${GITHUBTOKEN}@github.com/antholzer/testtex
+- git pull
+- git push origin-token :assets && git branch -d assets
+- git checkout --orphan assets
+- git rm -rf fonts/ && git rm *.tex *.sty *.cls *.pdf && git add *.png
+- git config user.email "htuinhof@gmail.com" && git config user.name "hesseltuinhof"
+- git commit -m "auto update by travis" && git push origin-token assets

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,9 @@ script:
 - tectonic ./cv.tex --print
 - tectonic ./cover.tex --print
 after_success:
-- convert -density 600 cv.pdf -quality 90 cv.png
-- convert -density 600 cover.pdf -quality 90 cover.png
-- git remote add origin-token https://${GITHUBTOKEN}@github.com/hesseltuinhof/simpleCV
-- git push origin-token :assets
-- git branch -d assets
-- git checkout --orphan assets
-- git rm -rf fonts/ && git rm -f *.tex *.sty *.cls
-- git add cv.png cv.pdf cover.png cover.pdf
-- git config user.email "travis@travis-ci.org" && git config user.name "Travis CI"
-- git commit -m "Travis auto upload $TRAVIS_BUILD_NUMBER" && git push --quiet origin-token assets
+- ./push.sh
+branches:
+  except:
+  - assets
+after_success:
+- ./push.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,25 +17,14 @@ cache:
 script:
 - tectonic ./cv.tex --print
 - tectonic ./cover.tex --print
-before_deploy:
+after_success:
 - convert -density 600 cv.pdf -quality 90 cv.png
 - convert -density 600 cover.pdf -quality 90 cover.png
-deploy:
-  provider: releases
-  token:
-    secure: # TODO add key
-  file:
-  - cv.pdf
-  - cover.pdf
-  cleanup: false
-  on:
-    tags: true
-  edge: true
-after_deploy:
 - git remote add origin-token https://${GITHUBTOKEN}@github.com/hesseltuinhof/simpleCV
-- git pull
-- git push origin-token :assets && git branch -d assets
+- git push origin-token :assets
+- git branch -d assets
 - git checkout --orphan assets
-- git rm -rf fonts/ && git rm *.tex *.sty *.cls *.pdf && git add *.png
-- git config user.email "htuinhof@gmail.com" && git config user.name "hesseltuinhof"
-- git commit -m "auto update by travis" && git push origin-token assets
+- git rm -rf fonts/ && git rm -f *.tex *.sty *.cls
+- git add cv.png cv.pdf cover.png cover.pdf
+- git config user.email "travis@travis-ci.org" && git config user.name "Travis CI"
+- git commit -m "Travis auto upload $TRAVIS_BUILD_NUMBER" && git push --quiet origin-token assets

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,17 @@ before_deploy:
 - convert -density 600 cover.pdf -quality 90 cover.png
 deploy:
   provider: releases
-  api_key:
+  token:
     secure: # TODO add key
   file:
   - cv.pdf
   - cover.pdf
-  skip_cleanup: true
+  cleanup: false
   on:
     tags: true
+  edge: true
 after_deploy:
-- git remote add origin-token https://${GITHUBTOKEN}@github.com/antholzer/testtex
+- git remote add origin-token https://${GITHUBTOKEN}@github.com/hesseltuinhof/simpleCV
 - git pull
 - git push origin-token :assets && git branch -d assets
 - git checkout --orphan assets

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,7 @@ script:
 - tectonic ./cv.tex --print
 - tectonic ./cover.tex --print
 after_success:
-- ./push.sh
+- ./.push.sh
 branches:
   except:
   - assets
-after_success:
-- ./push.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_install:
 - sudo apt-get install -y imagemagick ghostscript
 # converting PDFs is disabled by default (for security)
 - sudo sed -i '/PDF/s/none/write|read/g' /etc/ImageMagick-6/policy.xml
+- sudo apt-get install -y fonts-roboto
 install:
 - export PATH="$HOME/miniconda/bin:$PATH"
 - if ! command -v conda > /dev/null; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # What about simpleCV?
+
+[![Build Status](https://travis-ci.org/hesseltuinhof/simpleCV.svg?branch=master)](https://travis-ci.org/hesseltuinhof/simpleCV)
+
 This repository provides LaTeX templates for a **simple CV** and **cover letter** with a sleek and
 elegant look. It is intended to be used not only by the modern STEM graduate but also by anyone who
 seeks a straightforward, comprehensible and easy to modify implementation. Part of our design was
@@ -8,7 +11,7 @@ well as [Awesome CV](https://github.com/posquit0/Awesome-CV).
 ## Preview
 | CV | Cover Letter |
 |:---:|:---:|
-|[![CV PREVIEW](https://github.com/antholzer/media/blob/master/simpleCV/cv.png?raw=True)](https://github.com/antholzer/media/blob/master/simpleCV/cv.pdf) | [![Cover PREVIEW](https://github.com/antholzer/media/blob/master/simpleCV/cover.png?raw=True)](https://github.com/antholzer/media/blob/master/simpleCV/cover.pdf)
+|[![CV PREVIEW](https://github.com/hesseltuinhof/simpleCV/blob/assets/cv.png?raw=True)](https://github.com/hesseltuinhof/simpleCV/releases/latest/download/cv.pdf) | [![Cover PREVIEW](https://github.com/hesseltuinhof/simpleCV/blob/assets/cover.png?raw=True)](https://github.com/hesseltuinhof/simpleCV/releases/latest/download/cover.pdf)
 
 ## Install Notes
 Make sure that you have [Google's Roboto](https://github.com/google/roboto) installed. If you want

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # What about simpleCV?
 
-[![Build Status](https://travis-ci.org/hesseltuinhof/simpleCV.svg?branch=master)](https://travis-ci.org/hesseltuinhof/simpleCV)
+[![Build Status](https://travis-ci.com/hesseltuinhof/simpleCV.svg?branch=master)](https://travis-ci.com/hesseltuinhof/simpleCV)
 
 This repository provides LaTeX templates for a **simple CV** and **cover letter** with a sleek and
 elegant look. It is intended to be used not only by the modern STEM graduate but also by anyone who
@@ -11,7 +11,7 @@ well as [Awesome CV](https://github.com/posquit0/Awesome-CV).
 ## Preview
 | CV | Cover Letter |
 |:---:|:---:|
-|[![CV PREVIEW](https://github.com/hesseltuinhof/simpleCV/blob/assets/cv.png?raw=True)](https://github.com/hesseltuinhof/simpleCV/releases/latest/download/cv.pdf) | [![Cover PREVIEW](https://github.com/hesseltuinhof/simpleCV/blob/assets/cover.png?raw=True)](https://github.com/hesseltuinhof/simpleCV/releases/latest/download/cover.pdf)
+|[![CV PREVIEW](https://github.com/hesseltuinhof/simpleCV/blob/assets/cv.png?raw=True)](https://github.com/hesseltuinhof/simpleCV/blob/assets/cv.pdf?raw=True) | [![Cover PREVIEW](https://github.com/hesseltuinhof/simpleCV/blob/assets/cover.png?raw=True)](https://github.com/hesseltuinhof/simpleCV/blob/assets/cover.pdf?raw=True)
 
 ## Install Notes
 Make sure that you have [Google's Roboto](https://github.com/google/roboto) installed. If you want

--- a/push.sh
+++ b/push.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [[ "$TRAVIS_BRANCH" != "master" ]]
+then
+    echo "not master branch. skipping update of assets"
+    exit 0
+fi
+
+convert -density 600 test.pdf -quality 90 test.png
+
+# TODO: change env variabels encrypted_*
+openssl aes-256-cb -k $encrypted_e6cc0fb2b8da_key -iv $encrypted_e6cc0fb2b8da_iv -in .push-token.enc -out push-token -d
+chmod 600 push-token
+eval $(ssh-agent -s)
+ssh-add push-token
+rm push-token
+
+git remote add origin-token git@github.com:hesseltuinhof/simpleCV.git
+
+if [[ $(git ls-remote origin assets | wc -l) == "1" ]]
+then
+    git push origin-token :assets
+fi
+
+git checkout --orphan assets
+git rm -rf fonts/ && git rm -f *.tex *.sty *.cls .push-token.enc
+git add cv.png cv.pdf cover.png cover.pdf
+git config user.email "travis@travis-ci.org"
+git config user.name "travis ci"
+git commit -m "travis auto upload $TRAVIS_BUILD_NUMBER"
+git push -u origin-token assets > /dev/null 2>&1

--- a/push.sh
+++ b/push.sh
@@ -9,7 +9,7 @@ fi
 convert -density 600 test.pdf -quality 90 test.png
 
 # TODO: change env variabels encrypted_*
-openssl aes-256-cb -k $encrypted_e6cc0fb2b8da_key -iv $encrypted_e6cc0fb2b8da_iv -in .push-token.enc -out push-token -d
+openssl aes-256-cbc -K $encrypted_e6cc0fb2b8da_key -iv $encrypted_e6cc0fb2b8da_iv -in .push-token.enc -out push-token -d
 chmod 600 push-token
 eval $(ssh-agent -s)
 ssh-add push-token


### PR DESCRIPTION
Added travis file to automatically compile it (mostly based on [github.com/PHPirates/travis-ci-latex-pdf](https://github.com/PHPirates/travis-ci-latex-pdf)).

@hesseltuinhof to enable it you need to enable travis on github via the [marketplace](https://github.com/marketplace/travis-ci) (make sure to select the free plan).

Then you need to create a [Github Token](https://github.com/settings/tokens/new) (with access rights to public repos) and add it to the env. variables (as "GITHUBTOKEN") on the repo on travis e.g. under https://travis-ci.com/hesseltuinhof/simpleCV/settings.

**Edit**: Just do the stuff from above.
If we do not want to create releases below can be ignored. You only delete the `deploy` section in `.travis.yml` (I can do that too).

-------
The token is also needed in the `.travis.yml` file. 

```
git pull && git checkout ci
sudo gem install travis --no-rdoc --no-ri
travis encrypt <token>
```
and then add the `deploy: token: secure:` entry to the `.travis.yml` file.

Compilation gets tested after each commit. PDFs get uploaded to releases and PNGs to a new branch (releases can not be used as preview in Readme).